### PR TITLE
✨ feat & refactor: useOutsideClick 커스텀 훅 구현 및 Popover 컴포넌트 리팩토링

### DIFF
--- a/src/components/Overlay/Popover/Popover.tsx
+++ b/src/components/Overlay/Popover/Popover.tsx
@@ -28,7 +28,7 @@ const Popover = ({ children, placement, ...props }: PopoverProps) => {
     onToggle: togglePopover,
     triggerRef,
     popoverRef,
-    wrapRef,
+    ref: wrapRef,
   } = usePopover();
   const [contentPosition, setContentPosition] = useState({ top: 0, left: 0 });
 

--- a/src/components/Overlay/Popover/usePopover.ts
+++ b/src/components/Overlay/Popover/usePopover.ts
@@ -1,5 +1,6 @@
+import { useOutsideClick } from "@/hooks";
 import useDisclosure from "@/hooks/useDisclosure";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 export type UsePopoverProps = {};
 
@@ -8,20 +9,8 @@ export function usePopover() {
 
   const triggerRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    const pageClick = (e: any) => {
-      if (!wrapRef.current?.contains(e.target)) {
-        onClose();
-      }
-    };
-    window.addEventListener("click", pageClick);
+  const { ref } = useOutsideClick({ callback: onClose });
 
-    return () => {
-      window.removeEventListener("click", pageClick);
-    };
-  }, []);
-
-  return { isOpen, onOpen, onClose, onToggle, triggerRef, popoverRef, wrapRef };
+  return { isOpen, onOpen, onClose, onToggle, triggerRef, popoverRef, ref };
 }

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,3 +1,21 @@
-const useOutsideClick = () => {};
+import { useEffect, useRef } from "react";
+
+const useOutsideClick = ({ callback }: { callback: () => void }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const pageClick = (e: any) => {
+      if (!ref.current?.contains(e.target)) {
+        callback();
+      }
+    };
+    window.addEventListener("click", pageClick);
+
+    return () => {
+      window.removeEventListener("click", pageClick);
+    };
+  }, []);
+
+  return { ref };
+};
 
 export default useOutsideClick;


### PR DESCRIPTION
## 📌 이슈 링크

- close #

<br/>

## 📖 작업 배경

-

<br/>

## 🛠️ 구현 내용

- useOutsideClick 커스텀 훅 구현 
- Popover 컴포넌트 리팩토링

<br/>

## 💡 참고사항

-

<br/>

## 🖼️ 스크린샷

-

<br/>
