### PR TITLE
refactor & docs: children을 사용하는 props PropsWithChildren으로 대체 & Toast 컴포넌트 storybook 코드 수정

### DIFF
--- a/src/components/DataDisplay/Badge/Badge.tsx
+++ b/src/components/DataDisplay/Badge/Badge.tsx
@@ -1,9 +1,13 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { BadgeVariants, badge } from "./Badge.css";
-type BadgeProps = BadgeVariants & {
-  children: ReactNode;
-};
-const Badge = ({ children, color, size, variant, ...props }: BadgeProps) => {
+
+const Badge = ({
+  children,
+  color,
+  size,
+  variant,
+  ...props
+}: PropsWithChildren<BadgeVariants>) => {
   return (
     <div className={badge({ color, size, variant })} {...props}>
       {children}

--- a/src/components/DataDisplay/Card/Card.tsx
+++ b/src/components/DataDisplay/Card/Card.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { CardVariants, card } from "./Card.css";
-type CardProps = CardVariants & {
-  children: ReactNode;
-};
+
 const Card = ({
   children,
   variant,
@@ -11,7 +9,7 @@ const Card = ({
   justify,
   direction,
   ...props
-}: CardProps) => {
+}: PropsWithChildren<CardVariants>) => {
   return (
     <article
       className={card({ variant, size, align, justify, direction })}

--- a/src/components/DataDisplay/Card/CardBody.tsx
+++ b/src/components/DataDisplay/Card/CardBody.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
-const CardBody = ({ children }: { children: ReactNode }) => {
+const CardBody = ({ children }: PropsWithChildren) => {
   return <section>{children}</section>;
 };
 

--- a/src/components/DataDisplay/Card/CardFooter.tsx
+++ b/src/components/DataDisplay/Card/CardFooter.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
-const CardFooter = ({ children }: { children: ReactNode }) => {
+const CardFooter = ({ children }: PropsWithChildren) => {
   return <footer>{children}</footer>;
 };
 

--- a/src/components/DataDisplay/Card/CardHeader.tsx
+++ b/src/components/DataDisplay/Card/CardHeader.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
-const CardHeader = ({ children }: { children: ReactNode }) => {
+const CardHeader = ({ children }: PropsWithChildren) => {
   return <header>{children}</header>;
 };
 

--- a/src/components/DataDisplay/List/List.tsx
+++ b/src/components/DataDisplay/List/List.tsx
@@ -1,9 +1,12 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { ListVariants, list } from "./List.css";
-export type ListProps = ListVariants & {
-  children?: ReactNode;
-};
-const List = ({ children, direction, space, ...props }: ListProps) => {
+
+const List = ({
+  children,
+  direction,
+  space,
+  ...props
+}: PropsWithChildren<ListVariants>) => {
   return (
     <ul className={list({ direction, space })} {...props}>
       {children}

--- a/src/components/DataDisplay/List/ListItem.tsx
+++ b/src/components/DataDisplay/List/ListItem.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { item } from "./List.css";
 
-const ListItem = ({ children }: { children: ReactNode }) => {
+const ListItem = ({ children }: PropsWithChildren) => {
   return <li className={item}>{children}</li>;
 };
 

--- a/src/components/DataDisplay/Table/Table.tsx
+++ b/src/components/DataDisplay/Table/Table.tsx
@@ -1,17 +1,14 @@
-import { ReactNode, createContext, useContext } from "react";
+import { PropsWithChildren, createContext, useContext } from "react";
 import { TableVariants, table } from "./Table.css";
 
-type TableContextProps = {
-  variant?: "simple" | "unstyled" | undefined;
-  size?: "sm" | "md" | "lg" | undefined;
-};
+const TableContext = createContext<TableVariants>({});
 
-const TableContext = createContext<TableContextProps>({});
-
-type TableProps = TableVariants & {
-  children?: ReactNode;
-};
-const Table = ({ children, variant, size = "lg", ...props }: TableProps) => {
+const Table = ({
+  children,
+  variant,
+  size = "lg",
+  ...props
+}: PropsWithChildren<TableVariants>) => {
   return (
     <TableContext.Provider value={{ variant, size }}>
       <table className={table({ variant })} {...props}>

--- a/src/components/DataDisplay/Table/TableContainer.tsx
+++ b/src/components/DataDisplay/Table/TableContainer.tsx
@@ -1,11 +1,7 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { container } from "./Table.css";
 
-type Props = {
-  children: ReactNode;
-};
-
-const TableContainer = ({ children }: Props) => {
+const TableContainer = ({ children }: PropsWithChildren) => {
   return <div className={container}>{children}</div>;
 };
 

--- a/src/components/DataDisplay/Table/Tbody.tsx
+++ b/src/components/DataDisplay/Table/Tbody.tsx
@@ -1,6 +1,6 @@
-import { ChildrenProps } from "@/types";
+import { PropsWithChildren } from "react";
 
-const Tbody = ({ children }: ChildrenProps) => {
+const Tbody = ({ children }: PropsWithChildren) => {
   return <tbody>{children}</tbody>;
 };
 

--- a/src/components/DataDisplay/Table/Td.tsx
+++ b/src/components/DataDisplay/Table/Td.tsx
@@ -1,8 +1,8 @@
-import { ChildrenProps } from "@/types";
 import { td } from "./Table.css";
 import { useTableContext } from "./Table";
+import { PropsWithChildren } from "react";
 
-const Td = ({ children }: ChildrenProps) => {
+const Td = ({ children }: PropsWithChildren) => {
   const { size } = useTableContext();
   return <td className={td({ size })}>{children}</td>;
 };

--- a/src/components/DataDisplay/Table/Tfoot.tsx
+++ b/src/components/DataDisplay/Table/Tfoot.tsx
@@ -1,6 +1,6 @@
-import { ChildrenProps } from "@/types";
+import { PropsWithChildren } from "react";
 
-const Tfoot = ({ children }: ChildrenProps) => {
+const Tfoot = ({ children }: PropsWithChildren) => {
   return <tfoot>{children}</tfoot>;
 };
 

--- a/src/components/DataDisplay/Table/Th.tsx
+++ b/src/components/DataDisplay/Table/Th.tsx
@@ -1,8 +1,8 @@
-import { ChildrenProps } from "@/types";
 import { th } from "./Table.css";
 import { useTableContext } from "./Table";
+import { PropsWithChildren } from "react";
 
-const Th = ({ children }: ChildrenProps) => {
+const Th = ({ children }: PropsWithChildren) => {
   const { size } = useTableContext();
   return <th className={th({ size })}>{children}</th>;
 };

--- a/src/components/DataDisplay/Table/Thead.tsx
+++ b/src/components/DataDisplay/Table/Thead.tsx
@@ -1,6 +1,6 @@
-import { ChildrenProps } from "@/types";
+import { PropsWithChildren } from "react";
 
-const Thead = ({ children }: ChildrenProps) => {
+const Thead = ({ children }: PropsWithChildren) => {
   return <thead>{children}</thead>;
 };
 

--- a/src/components/DataDisplay/Table/Tr.tsx
+++ b/src/components/DataDisplay/Table/Tr.tsx
@@ -1,8 +1,8 @@
-import { ChildrenProps } from "@/types";
 import { tr } from "./Table.css";
 import { useTableContext } from "./Table";
+import { PropsWithChildren } from "react";
 
-const Tr = ({ children }: ChildrenProps) => {
+const Tr = ({ children }: PropsWithChildren) => {
   const { variant } = useTableContext();
   return <tr className={tr({ variant })}>{children}</tr>;
 };

--- a/src/components/DataDisplay/Tag/Tag.tsx
+++ b/src/components/DataDisplay/Tag/Tag.tsx
@@ -1,10 +1,12 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { TagVariants, tag } from "./Tag.css";
 
-type TagProps = TagVariants & {
-  children: ReactNode;
-};
-const Tag = ({ children, color, variant, ...props }: TagProps) => {
+const Tag = ({
+  children,
+  color,
+  variant,
+  ...props
+}: PropsWithChildren<TagVariants>) => {
   return (
     <div className={tag({ color, variant })} {...props}>
       {children}

--- a/src/components/DataDisplay/Tag/TagLabel.tsx
+++ b/src/components/DataDisplay/Tag/TagLabel.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
-type TagLabelProps = {
-  children: ReactNode;
-};
-const TagLabel = ({ children }: TagLabelProps) => {
+import { PropsWithChildren } from "react";
+
+const TagLabel = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Disclosure/Tabs/Tab.tsx
+++ b/src/components/Disclosure/Tabs/Tab.tsx
@@ -1,14 +1,22 @@
-import { ForwardedRef, ReactNode, Ref, forwardRef, useState } from "react";
+import {
+  ForwardedRef,
+  PropsWithChildren,
+  Ref,
+  forwardRef,
+  useState,
+} from "react";
 import { useTabsContext } from "./Tabs";
 import { tab } from "./Tabs.css";
 import { useTabListContext } from "./TabList";
 import useCollectRefs from "@/hooks/useCollectRefs";
 type Props = {
-  children: ReactNode;
   isDisabled?: boolean;
 };
 const Tab = forwardRef(
-  ({ children, isDisabled }: Props, ref: ForwardedRef<HTMLButtonElement>) => {
+  (
+    { children, isDisabled }: PropsWithChildren<Props>,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ) => {
     const { changeTab, currentTab, size, onChange, isFitted, variant } =
       useTabsContext();
 

--- a/src/components/Disclosure/Tabs/Tabs.tsx
+++ b/src/components/Disclosure/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import {
-  ReactNode,
+  PropsWithChildren,
   createContext,
   useCallback,
   useContext,
@@ -18,7 +18,6 @@ const TabsContext = createContext<TabsContextProps | null>(null);
 
 export type TabsProps = TabListVariants &
   TabVariants & {
-    children?: ReactNode;
     defaultIdex?: number;
     onChange?: (index: number) => void;
     isFitted?: boolean;
@@ -35,7 +34,7 @@ const Tabs = ({
   variant,
   orientation,
   ...props
-}: TabsProps) => {
+}: PropsWithChildren<TabsProps>) => {
   const [currentTab, setCurrentTab] = useState(defaultIdex || 0);
 
   const changeTab = useCallback((tab: number) => {

--- a/src/components/Disclosure/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/Disclosure/VisuallyHidden/VisuallyHidden.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { PropsWithChildren } from "react";
 import { visuallyHidden } from "./VisuallyHidden.css";
 
 type Props = {
@@ -9,7 +9,7 @@ export const VisuallyHidden = ({
   as = "div",
   children,
   ...props
-}: React.PropsWithChildren<Props>) => {
+}: PropsWithChildren<Props>) => {
   return (
     <div className={visuallyHidden} {...props}>
       {children}

--- a/src/components/Feedback/Skeleton/Skeleton.tsx
+++ b/src/components/Feedback/Skeleton/Skeleton.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import {
   skeletonBackground,
   skeletonHeight,
@@ -12,7 +12,6 @@ type SkeletonProps = {
   width: string;
   height: string;
   radius: string;
-  children?: ReactNode;
   background: string;
 };
 
@@ -23,7 +22,7 @@ const Skeleton = ({
   children,
   background,
   ...props
-}: SkeletonProps) => {
+}: PropsWithChildren<SkeletonProps>) => {
   return (
     <div
       className={skeletonPlaceholder}

--- a/src/components/Feedback/Toast/Toast.stories.tsx
+++ b/src/components/Feedback/Toast/Toast.stories.tsx
@@ -47,27 +47,36 @@ const Component = (args: any) => {
 
 export const Success: Story = {
   args: {
-    title: "Toast입니다!",
-    description: "Toast 설명입니다!",
+    title: "Scheduled: Catch up ",
+    description: "Friday, February 10, 2023 at 5:57 PM",
     status: "success",
   },
   render: Component,
 };
 
-export const Error: Story = {
+export const Warning: Story = {
   args: {
-    title: "Toast입니다!",
-    description: "Toast 설명입니다!",
-    status: "error",
+    title: "Scheduled: Catch up ",
+    description: "Friday, February 10, 2023 at 5:57 PM",
+    status: "warning",
   },
   render: Component,
 };
 
-export const Loading: Story = {
+export const Danger: Story = {
   args: {
-    title: "Toast입니다!",
-    description: "Toast 설명입니다!",
-    status: "loading",
+    title: "Scheduled: Catch up ",
+    description: "Friday, February 10, 2023 at 5:57 PM",
+    status: "danger",
+  },
+  render: Component,
+};
+
+export const Info: Story = {
+  args: {
+    title: "Scheduled: Catch up ",
+    description: "Friday, February 10, 2023 at 5:57 PM",
+    status: "info",
   },
   render: Component,
 };

--- a/src/components/Feedback/Toast/ToastProvider.tsx
+++ b/src/components/Feedback/Toast/ToastProvider.tsx
@@ -1,10 +1,12 @@
-import { ReactNode, createContext, useId, useMemo, useState } from "react";
+import {
+  PropsWithChildren,
+  createContext,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import ToastList from "./ToastList";
 import { Toast } from "./Toast";
-
-type Props = {
-  children: ReactNode;
-};
 
 type ToastDispatchContextProps = {
   open: (toast: Toast) => void;
@@ -20,7 +22,7 @@ export const ToastDispatchContext = createContext<ToastDispatchContextProps>({
 
 let num = 0;
 
-const ToastProvider = ({ children }: Props) => {
+const ToastProvider = ({ children }: PropsWithChildren) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const memoizedToasts = useMemo(() => toasts, [toasts]);
   const id = useId();

--- a/src/components/FeedbackArea.tsx
+++ b/src/components/FeedbackArea.tsx
@@ -89,7 +89,7 @@ const FeedbackArea = () => {
               title: "Scheduled: Catch up ",
               description: "Friday, February 10, 2023 at 5:57 PM",
               status: "info",
-              position: "topRight",
+              position: "bottomRight",
             })
           }
         >

--- a/src/components/Form/Button/Button.tsx
+++ b/src/components/Form/Button/Button.tsx
@@ -33,6 +33,7 @@ const Button = forwardRef(
       loadingText,
       spinner,
       spinnerPlacement = "left",
+      children,
       ...props
     }: ButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
@@ -66,7 +67,7 @@ const Button = forwardRef(
           ) : (
             <>
               {leftIcon}
-              {props.children}
+              {children}
               {rightIcon}
             </>
           )}

--- a/src/components/Other/Portal/Portal.tsx
+++ b/src/components/Other/Portal/Portal.tsx
@@ -1,9 +1,7 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { createPortal } from "react-dom";
-type PortalProps = {
-  children: ReactNode;
-};
-const Portal = ({ children }: PortalProps) => {
+
+const Portal = ({ children }: PropsWithChildren) => {
   return <>{createPortal(children, document.body)}</>;
 };
 

--- a/src/components/Overlay/Drawer/Drawer.tsx
+++ b/src/components/Overlay/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext } from "react";
+import { PropsWithChildren, createContext, useContext } from "react";
 import { DrawerVariants, drawer } from "./Drawer.css";
 import Portal from "../../Other/Portal/Portal";
 
@@ -9,7 +9,6 @@ type DrawerContextProps = DrawerVariants & {
 const DrawerContext = createContext<DrawerContextProps | null>(null);
 
 type DrawerProps = DrawerVariants & {
-  children: ReactNode;
   onClose: () => void;
 };
 
@@ -19,7 +18,7 @@ const Drawer = ({
   isOpen,
   onClose,
   ...props
-}: DrawerProps) => {
+}: PropsWithChildren<DrawerProps>) => {
   return (
     <Portal>
       <div className={drawer({ isOpen })} {...props}>

--- a/src/components/Overlay/Drawer/DrawerBody.tsx
+++ b/src/components/Overlay/Drawer/DrawerBody.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
-type Props = {
-  children: ReactNode;
-};
-const DrawerBody = ({ children }: Props) => {
+import { PropsWithChildren, ReactNode } from "react";
+
+const DrawerBody = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Overlay/Drawer/DrawerContent.tsx
+++ b/src/components/Overlay/Drawer/DrawerContent.tsx
@@ -1,10 +1,8 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { drawerContent } from "./Drawer.css";
 import { useDrawerContext } from "./Drawer";
-type Props = {
-  children: ReactNode;
-};
-const DrawerContent = ({ children }: Props) => {
+
+const DrawerContent = ({ children }: PropsWithChildren) => {
   const { placement, isOpen } = useDrawerContext();
 
   return <div className={drawerContent({ placement, isOpen })}>{children}</div>;

--- a/src/components/Overlay/Drawer/DrawerFooter.tsx
+++ b/src/components/Overlay/Drawer/DrawerFooter.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
-type Props = {
-  children: ReactNode;
-};
-const DrawerFooter = ({ children }: Props) => {
+import { PropsWithChildren } from "react";
+
+const DrawerFooter = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Overlay/Drawer/DrawerHeader.tsx
+++ b/src/components/Overlay/Drawer/DrawerHeader.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
-type Props = {
-  children: ReactNode;
-};
-const DrawerHeader = ({ children }: Props) => {
+import { PropsWithChildren } from "react";
+
+const DrawerHeader = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Overlay/Menu/MenuButton.tsx
+++ b/src/components/Overlay/Menu/MenuButton.tsx
@@ -1,12 +1,8 @@
-import { KeyboardEvent, ReactNode } from "react";
+import { KeyboardEvent, PropsWithChildren } from "react";
 import { useMenuContext } from "./Menu";
 import { button } from "./Menu.css";
 
-type MenuButtonProps = {
-  children: ReactNode;
-};
-
-const MenuButton = ({ children }: MenuButtonProps) => {
+const MenuButton = ({ children }: PropsWithChildren) => {
   const { toggleMenu, itemRefs, isVisible, variant } = useMenuContext();
 
   const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {

--- a/src/components/Overlay/Modal/Modal.css.ts
+++ b/src/components/Overlay/Modal/Modal.css.ts
@@ -36,7 +36,6 @@ export const overlay = sprinkles({
 
 export const modal = style([
   sprinkles({
-    position: "absolute",
     backgroundColor: "white",
     borderRadius: "lg",
     padding: "5",

--- a/src/components/Overlay/Modal/Modal.stories.tsx
+++ b/src/components/Overlay/Modal/Modal.stories.tsx
@@ -28,9 +28,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Left: Story = {
-  args: {
-    children: <></>,
-  },
+  args: {},
   render: function Render() {
     const { isOpen, onClose, onOpen } = useDisclosure();
     return (

--- a/src/components/Overlay/Modal/Modal.tsx
+++ b/src/components/Overlay/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext } from "react";
+import { PropsWithChildren, createContext, useContext } from "react";
 import { wrap } from "./Modal.css";
 import Portal from "../../Other/Portal/Portal";
 
@@ -10,15 +10,20 @@ type ModalContext = {
 const ModalContext = createContext<ModalContext | null>(null);
 
 export type ModalProps = {
-  children?: ReactNode;
   onClose: () => void;
-  isOpen?: boolean;
+  isOpen: boolean;
 };
-const Modal = ({ children, onClose, isOpen, ...props }: ModalProps) => {
+const Modal = ({
+  children,
+  onClose,
+  isOpen,
+  ...props
+}: PropsWithChildren<ModalProps>) => {
   const value = {
     onClose,
     isOpen,
   };
+
   return (
     isOpen && (
       <Portal>

--- a/src/components/Overlay/Modal/ModalBody.tsx
+++ b/src/components/Overlay/Modal/ModalBody.tsx
@@ -1,9 +1,6 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
-type Props = {
-  children: ReactNode;
-};
-const ModalBody = ({ children }: Props) => {
+const ModalBody = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Overlay/Modal/ModalContent.tsx
+++ b/src/components/Overlay/Modal/ModalContent.tsx
@@ -1,9 +1,7 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { modal } from "./Modal.css";
-type Props = {
-  children: ReactNode;
-};
-const ModalContent = ({ children }: Props) => {
+
+const ModalContent = ({ children }: PropsWithChildren) => {
   return <div className={modal}>{children}</div>;
 };
 

--- a/src/components/Overlay/Modal/ModalFooter.tsx
+++ b/src/components/Overlay/Modal/ModalFooter.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
-type Props = {
-  children: ReactNode;
-};
-const ModalFooter = ({ children }: Props) => {
+import { PropsWithChildren } from "react";
+
+const ModalFooter = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Overlay/Modal/ModalHeader.tsx
+++ b/src/components/Overlay/Modal/ModalHeader.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react";
-type Props = {
-  children: ReactNode;
-};
-const ModalHeader = ({ children }: Props) => {
+import { PropsWithChildren } from "react";
+
+const ModalHeader = ({ children }: PropsWithChildren) => {
   return <div>{children}</div>;
 };
 

--- a/src/components/Overlay/Popover/Popover.tsx
+++ b/src/components/Overlay/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext } from "react";
+import { PropsWithChildren, createContext, useContext } from "react";
 import { wrap } from "./Popover.css";
 import { usePopper } from "@/hooks";
 
@@ -15,10 +15,13 @@ type PopoverContextProps = {
 const PopoverContext = createContext<PopoverContextProps | null>(null);
 
 type PopoverProps = {
-  children: ReactNode;
   placement?: string;
 };
-const Popover = ({ children, placement, ...props }: PopoverProps) => {
+const Popover = ({
+  children,
+  placement,
+  ...props
+}: PropsWithChildren<PopoverProps>) => {
   const {
     isOpen: isVisible,
     onClose,

--- a/src/components/Overlay/Popover/PopoverTrigger.tsx
+++ b/src/components/Overlay/Popover/PopoverTrigger.tsx
@@ -1,9 +1,7 @@
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 import { usePopoverContext } from "./Popover";
-type Props = {
-  children: ReactNode;
-};
-const PopoverTrigger = ({ children }: Props) => {
+
+const PopoverTrigger = ({ children }: PropsWithChildren) => {
   const { togglePopover, triggerRef } = usePopoverContext();
   return (
     <div ref={triggerRef} onClick={togglePopover}>

--- a/src/css/sprinkles.css.ts
+++ b/src/css/sprinkles.css.ts
@@ -87,7 +87,7 @@ const responsiveProperties = defineProperties({
     captionSide: ["bottom", "top"],
     zIndex: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
     userSelect: ["none"],
-    transform: ["rotate(45deg)"],
+    transform: ["rotate(45deg)", "translate(-50%, -50%)"],
     wordWrap: ["break-word"],
     zoom: [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5],
   },


### PR DESCRIPTION
## 📌 이슈 링크

- close #

<br/>

## 📖 작업 배경

-

<br/>

## 🛠️ 구현 내용

- children을 사용하는 props PropsWithChildren으로 대체
- Toast 컴포넌트 storybook 코드 수정

<br/>

## 💡 참고사항

-

<br/>

## 🖼️ 스크린샷

-

<br/>
